### PR TITLE
libvips svs files error: forced openslide library linkage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
     --disable-static \
     --enable-gtk-doc-html=no \
     --enable-gtk-doc=no \
-    --enable-pyvips8=no && \
+    --enable-pyvips8=no \
+    --with-openslide \
   make && \
   make install && \
   ldconfig


### PR DESCRIPTION
Motivation:
Occasionally using imaginary with specific svs files would show the error:
```
source input: Compression scheme 33005 tile decoding is not implemented
source input: Compression scheme 33005 tile decoding is not implemented
```
The error was flagged in [libvips](https://github.com/libvips/libvips/issues/1109).
It is caused by a missing openslide library that enables the tool to handle multi-slide images.

By enforced  openslide to be compiled during the libvips configuration process the issue should be solved.