### PR TITLE
Enforcing libvips build with openslide library support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
     --disable-static \
     --enable-gtk-doc-html=no \
     --enable-gtk-doc=no \
-    --enable-pyvips8=no && \
+    --enable-pyvips8=no \
+    --with-openslide && \ 
   make && \
   make install && \
   ldconfig


### PR DESCRIPTION
Openslide is optionally used by libvips to read virtual slides.
This is specially important for the svs image format.
Since it is optional, there are versions of vips that are built without it. We need to enforce that vips is built with openslide support.

Without it this would cause the following error:
`Compression scheme 33005 tile decoding is not implemented`

References:
https://github.com/libvips/libvips/issues/1109
