### PR TITLE
SVS format jpeg2000 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.16
+ARG GOLANG_VERSION=1.17
 FROM golang:${GOLANG_VERSION} as builder
 
 ARG IMAGINARY_VERSION=dev
@@ -7,15 +7,19 @@ ARG GOLANGCILINT_VERSION=1.23.3
 
 # Installs libvips + required libraries
 RUN DEBIAN_FRONTEND=noninteractive \
-  apt-get update && \
+  apt-get upgrade && \
+  apt-get update && \ 
   apt-get install --no-install-recommends -y \
   ca-certificates \
   automake build-essential curl \
   gobject-introspection gtk-doc-tools libglib2.0-dev libjpeg62-turbo-dev libpng-dev \
   libwebp-dev libtiff5-dev libgif-dev libexif-dev libxml2-dev libpoppler-glib-dev \
   swig libmagickwand-dev libpango1.0-dev libmatio-dev libopenslide-dev libcfitsio-dev \
-  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev && \
-  cd /tmp && \
+  libgsf-1-dev fftw3-dev liborc-0.4-dev librsvg2-dev libopenjp2-7-dev libheif-dev \
+  libimagequant-dev 
+
+RUN cd /tmp && \
+  ldconfig && \
   curl -fsSLO https://github.com/libvips/libvips/releases/download/v${LIBVIPS_VERSION}/vips-${LIBVIPS_VERSION}.tar.gz && \
   tar zvxf vips-${LIBVIPS_VERSION}.tar.gz && \
   cd /tmp/vips-${LIBVIPS_VERSION} && \
@@ -27,8 +31,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
     --disable-static \
     --enable-gtk-doc-html=no \
     --enable-gtk-doc=no \
-    --enable-pyvips8=no \
-    --with-openslide && \ 
+    --with-openslide && \
   make && \
   make install && \
   ldconfig
@@ -53,7 +56,7 @@ RUN go build -a \
     -ldflags="-s -w -h -X main.Version=${IMAGINARY_VERSION}" \
     github.com/h2non/imaginary
 
-FROM debian:buster-slim
+FROM debian:stable-slim
 
 ARG IMAGINARY_VERSION
 
@@ -71,12 +74,14 @@ COPY --from=builder /usr/local/bin/vips /usr/local/bin/vips
 
 # Install runtime dependencies
 RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get upgrade && \ 
   apt-get update && \
   apt-get install --no-install-recommends -y \
-  libglib2.0-0 libjpeg62-turbo libpng16-16 libopenexr23 \
+  libglib2.0-0 libjpeg62-turbo libpng16-16 libopenexr25 \
   libwebp6 libwebpmux3 libwebpdemux2 libtiff5 libgif7 libexif12 libxml2 libpoppler-glib8 \
-  libmagickwand-6.q16-6 libpango1.0-0 libmatio4 libopenslide0 \
-  libgsf-1-114 fftw3 liborc-0.4-0 librsvg2-2 libcfitsio7 && \
+  libmagickwand-6.q16-6 libpango1.0-0 libmatio11 libopenslide0 \
+  libgsf-1-114 fftw3 liborc-0.4-0 librsvg2-2 libcfitsio9 libopenjp2-7 libheif1 \
+  libimagequant0 && \
   apt-get autoremove -y && \
   apt-get autoclean && \
   apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 ARG GOLANG_VERSION=1.17
 FROM golang:${GOLANG_VERSION} as builder
 
-ARG IMAGINARY_VERSION=dev
+#ARGS are changed during build - dev is just a placeholder
+ARG RELEASE=dev
+ARG COMMIT=dev
 ARG LIBVIPS_VERSION=8.11.2
 ARG GOLANGCILINT_VERSION=1.23.3
 
@@ -53,7 +55,7 @@ COPY . .
 # Compile imaginary
 RUN go build -a \
     -o ${GOPATH}/bin/imaginary \
-    -ldflags="-s -w -h -X main.Version=${IMAGINARY_VERSION}" \
+    -ldflags="-s -w -h -X main.Version=${RELEASE}-${COMMIT}" \
     github.com/h2non/imaginary
 
 FROM debian:stable-slim
@@ -65,7 +67,7 @@ LABEL maintainer="tomas@aparicio.me" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.url="https://github.com/h2non/imaginary" \
       org.label-schema.vcs-url="https://github.com/h2non/imaginary" \
-      org.label-schema.version="${IMAGINARY_VERSION}"
+      org.label-schema.version="${RELEASE}-${COMMIT}"
 
 COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /go/bin/imaginary /usr/local/bin/imaginary

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN DEBIAN_FRONTEND=noninteractive \
     --disable-static \
     --enable-gtk-doc-html=no \
     --enable-gtk-doc=no \
-    --enable-pyvips8=no && \
+    --enable-pyvips8=no \
+    --with-openslide && \ 
   make && \
   make install && \
   ldconfig


### PR DESCRIPTION
SVS images with a jpeg2000 compression were giving errors such as:

` Compression scheme 33005 tile decoding is not implemented`
and
`(process:1): VIPS-WARNING **: 10:15:03.130: error in tile 14848 x 0`

both were caused by missing libraries when building libvips. 
Most important changes:
- added openjpeg support with libopenjp2-7 
- added heif support with libheif
- added pngquant support with libpngquant
- updated os versions and packages